### PR TITLE
Prevent review advice from overwriting other plugins' output

### DIFF
--- a/src/main/resources/static/reviewassistant.js
+++ b/src/main/resources/static/reviewassistant.js
@@ -1,16 +1,24 @@
 Gerrit.install(function(self) {
     function print (c, r) {
+        var doc = document;
         var change_plugins = document.getElementById('change_plugins');
-        change_plugins.innerHTML = "<div id=\"reviewAssistant\" style=\"padding-top: 10px;\" ><strong>ReviewAssistant</strong><p><img src=\"plugins/reviewassistant/static/loading.gif\"></p></div>";
+        var container = doc.createElement('div');
+        container.id = "reviewAssistant";
+        container.style = "padding-top: 10px;";
+        var header = doc.createElement('div');
+        header.innerHTML = "<strong>ReviewAssistant</strong>";
+        container.appendChild(header);
+        var advice = doc.createElement('div');
+        advice.innerHtml = "<p><img src=\"plugins/reviewassistant/static/loading.gif\"></p>";
+        container.appendChild(advice);
+        change_plugins.appendChild(container);
         var url = "changes/" + c._number + "/revisions/" + r._number + "/reviewassistant~advice";
         console.log("Url is: " + url);
         console.log("Asking for advice...");
-        Gerrit.get(
-            url,
-            function (r) {
-                console.log("Got advice: " + r);
-                change_plugins.innerHTML = r;
-            });
+        Gerrit.get(url, function (r) {
+            console.log("Got advice: " + r);
+            advice.innerHTML = r;
+        });
     }
     self.on('showchange', print);
 });


### PR DESCRIPTION
Instead of overwriting the HTML of the change_plugins element with
the review advice, put the review advice in a separate div and then
append that to the change_plugins element.

Strip down the string returned from the REST API to only include
the actual result without the surrounding div element(s).

Use a StringBuilder rather than string concatenation to build the
result.

Also fix the apply method to return a String rather than Object,
and replace multiple exception throws with RestApiException which
is the base exception of all of them.

Change-Id: I4e1b548e22baff75720c775398ec95165e381d5b
